### PR TITLE
Add compile_directory.json

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,6 +170,34 @@ fn run_parser<'t>(
     }
 }
 
+fn directory_to_json(
+    directory: &FxIndexMap<Option<CompileId>, Vec<OutputFile>>,
+) -> serde_json::Value {
+    let mut json_map = serde_json::Map::new();
+
+    for (compile_id, output_files) in directory {
+        let key = compile_id
+            .as_ref()
+            .map_or_else(|| "unknown".to_string(), |cid| cid.to_string());
+
+        let artifacts: Vec<serde_json::Value> = output_files
+            .iter()
+            .map(|file| {
+                serde_json::json!({
+                    "url": file.url,
+                    // Strip away any leading directory names, that will just be in the url path anyway
+                    "name": file.name.split('/').last().unwrap_or(&file.name),
+                    "number": file.number,
+                    "suffix": file.suffix
+                })
+            })
+            .collect();
+
+        json_map.insert(key, serde_json::json!({"artifacts": artifacts}));
+    }
+    serde_json::Value::Object(json_map)
+}
+
 pub fn parse_path(path: &PathBuf, config: ParseConfig) -> anyhow::Result<ParseOutput> {
     let strict = config.strict;
     if !path.is_file() {
@@ -674,7 +702,10 @@ pub fn parse_path(path: &PathBuf, config: ParseConfig) -> anyhow::Result<ParseOu
                 .map_or("(unknown)".to_string(), |e| e.as_directory_name())
         })
         .collect();
-
+    output.push((
+        PathBuf::from("compile_directory.json"),
+        serde_json::to_string_pretty(&directory_to_json(&directory))?,
+    ));
     let index_context = IndexContext {
         css: CSS,
         javascript: JAVASCRIPT,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -14,6 +14,7 @@ fn test_parse_simple() {
         "-_0_0_0/aot_forward_graph",
         "-_0_0_0/dynamo_output_graph",
         "index.html",
+        "compile_directory.json",
         "failures_and_restarts.html",
         "-_0_0_0/inductor_post_grad_graph",
         "-_0_0_0/inductor_output_code",
@@ -49,6 +50,7 @@ fn test_parse_compilation_metrics() {
         "-_2_0_0/dynamo_output_graph",
         "-_2_0_0/compilation_metrics",
         "index.html",
+        "compile_directory.json",
         "failures_and_restarts.html",
     ];
     // Read the test file
@@ -78,6 +80,7 @@ fn test_parse_compilation_failures() {
         "-_0_0_0/dynamo_output_graph",
         "-_0_0_0/compilation_metrics",
         "index.html",
+        "compile_directory.json",
         "failures_and_restarts.html",
     ];
     // Read the test file
@@ -156,6 +159,7 @@ fn test_cache_hit_miss() {
         "-_1_0_0/fx_graph_cache_miss_33.json",
         "-_1_0_0/fx_graph_cache_miss_9.json",
         "-_1_0_0/fx_graph_cache_hit_20.json",
+        "compile_directory.json",
         "index.html",
     ];
     // Generated via TORCH_TRACE=~/trace_logs/test python test/inductor/test_codecache.py -k test_flex_attention_caching


### PR DESCRIPTION
Adds a new JSON representation of the compile directory, which basically has a list of output artifacts by name. Here's what an example json would look like:

```
{
  "[0/0]": {
    "artifacts": [
      {
        "name": "dynamo_output_graph_0.txt",
        "number": 0,
        "suffix": "",
        "url": "-_0_0_0/dynamo_output_graph_0.txt"
      },
      {
        "name": "aot_forward_graph_1.txt",
        "number": 1,
        "suffix": "",
        "url": "-_0_0_0/aot_forward_graph_1.txt"
      },
      {
        "name": "fx_graph_cache_hash_2.json",
        "number": 2,
        "suffix": "",
        "url": "-_0_0_0/fx_graph_cache_hash_2.json"
      },
      {
        "name": "dynamo_guards_3.html",
        "number": 3,
        "suffix": "",
        "url": "-_0_0_0/dynamo_guards_3.html"
      },
      {
        "name": "dynamo_cpp_guards_str_4.txt",
        "number": 4,
        "suffix": "",
        "url": "-_0_0_0/dynamo_cpp_guards_str_4.txt"
      },
      {
        "name": "compilation_metrics_5.html",
        "number": 5,
        "suffix": "",
        "url": "-_0_0_0/compilation_metrics_5.html"
      }
    ]
  }
}
```

Today, name and url are actually the same for basically all results. But that might change in the future and it's more generic to just dump the entire JSON. This allows external programs to understand the directory hierarchy and contents of the tlparse at a glance, without having to parse index.html
