### PR TITLE
In provenance tracking, process the last file instead of the first file

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -829,8 +829,10 @@ pub fn parse_path(path: &PathBuf, config: ParseConfig) -> anyhow::Result<ParseOu
             filename_pattern: &str,
             directory_name: &str,
         ) -> String {
+            // get the last file that include the filename_pattern in the output
             output
                 .iter()
+                .rev()
                 .find(|(path, _)| {
                     path.to_string_lossy()
                         .contains(&format!("{}/{}", directory_name, filename_pattern))


### PR DESCRIPTION
This makes it more robust to the case where two mapping jsons are produced. 