### PR TITLE
Public some types for external use

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ use crate::parsers::ParserOutput;
 use crate::parsers::StructuredLogParser;
 use crate::templates::*;
 use crate::types::*;
-mod parsers;
+pub mod parsers;
 mod templates;
 mod types;
 

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -13,6 +13,9 @@ use serde_json::Value;
 use syntect::highlighting::ThemeSet;
 use syntect::parsing::SyntaxSet;
 
+// Re-export types from types.rs for external use
+pub use crate::types::{CompileId, EmptyMetadata, Envelope, Metadata};
+
 pub enum ParserOutput {
     File(PathBuf, String),       // File to be saved on disk
     GlobalFile(PathBuf, String), // Like file, but don't give a unique suffix


### PR DESCRIPTION
To let tritonparseparser works on internal tlparse, we need to public those types in oss tlparse.