### PR TITLE
Add raw.jsonl support.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -917,10 +917,10 @@ pub fn parse_path(path: &PathBuf, config: ParseConfig) -> anyhow::Result<ParseOu
             };
         };
 
-        // Handle payload file writing and determine payload filename
+        // Handle payload file writing and determine payload filename, but skip chromium events
         let payload_filename = if let Some(ref expect) = e.has_payload {
-            // Only write payload file if no parser generated PayloadFile/PayloadReformatFile output
-            if !has_any_payload_output && !payload.is_empty() {
+            // Only write payload file if no parser generated PayloadFile/PayloadReformatFile output and not a chromium event
+            if !has_any_payload_output && !payload.is_empty() && e.chromium_event.is_none() {
                 let hash_str = expect;
                 let payload_path = PathBuf::from(format!("payloads/{}.txt", hash_str));
                 output.push((payload_path, payload.clone()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,7 +361,7 @@ pub fn parse_path(path: &PathBuf, config: ParseConfig) -> anyhow::Result<ParseOu
     // Store results in an output Vec<PathBuf, String>
     let mut output: Vec<(PathBuf, String)> = Vec::new();
 
-    // Store shortraw.log content (without payloads)
+    // Store raw.jsonl content (without payloads)
     let mut shortraw_content = String::new();
 
     let mut tt: TinyTemplate = TinyTemplate::new();
@@ -448,7 +448,7 @@ pub fn parse_path(path: &PathBuf, config: ParseConfig) -> anyhow::Result<ParseOu
          -> bool {
             if obj.contains_key(key) {
                 multi.suspend(|| {
-                    eprintln!("Key conflict: '{}' already exists in JSON payload, skipping shortraw JSONL conversion", key);
+                    eprintln!("Key conflict: '{}' already exists in JSON payload, skipping raw.jsonl JSONL conversion", key);
                 });
                 stats.fail_key_conflict += 1;
                 false
@@ -458,7 +458,7 @@ pub fn parse_path(path: &PathBuf, config: ParseConfig) -> anyhow::Result<ParseOu
             }
         };
 
-        // Create cleanup lambda to handle shortraw writing as JSONL
+        // Create cleanup lambda to handle raw.jsonl writing as JSONL
         let write_to_shortraw = |shortraw_content: &mut String,
                                  payload_filename: Option<String>,
                                  multi: &MultiProgress,
@@ -556,7 +556,7 @@ pub fn parse_path(path: &PathBuf, config: ParseConfig) -> anyhow::Result<ParseOu
                             }
                             Err(e) => {
                                 multi.suspend(|| {
-                                    eprintln!("Failed to serialize JSON for shortraw.log: {}", e);
+                                    eprintln!("Failed to serialize JSON for raw.jsonl: {}", e);
                                 });
                                 stats.fail_json_serialization += 1;
                                 // Drop line to maintain JSONL format - don't write anything
@@ -566,7 +566,7 @@ pub fn parse_path(path: &PathBuf, config: ParseConfig) -> anyhow::Result<ParseOu
                         // Not a JSON object, drop line to maintain JSONL format
                         multi.suspend(|| {
                             eprintln!(
-                                "JSON payload is not an object, dropping line from shortraw.log"
+                                "JSON payload is not an object, dropping line from raw.jsonl"
                             );
                         });
                         stats.fail_json += 1;
@@ -575,7 +575,7 @@ pub fn parse_path(path: &PathBuf, config: ParseConfig) -> anyhow::Result<ParseOu
                 Err(e) => {
                     // JSON parsing failed, drop line to maintain JSONL format
                     multi.suspend(|| {
-                        eprintln!("Failed to parse JSON envelope for shortraw.log: {}", e);
+                        eprintln!("Failed to parse JSON envelope for raw.jsonl: {}", e);
                     });
                     stats.fail_json += 1;
                 }
@@ -932,7 +932,7 @@ pub fn parse_path(path: &PathBuf, config: ParseConfig) -> anyhow::Result<ParseOu
             None
         };
 
-        // Write to shortraw.log with optional payload filename
+        // Write to raw.jsonl with optional payload filename
         write_to_shortraw(&mut shortraw_content, payload_filename, &multi, &mut stats);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -932,8 +932,10 @@ pub fn parse_path(path: &PathBuf, config: ParseConfig) -> anyhow::Result<ParseOu
             None
         };
 
-        // Write to raw.jsonl with optional payload filename
-        write_to_shortraw(&mut shortraw_content, payload_filename, &multi, &mut stats);
+        // Write to raw.jsonl with optional payload filename, but skip chromium events
+        if e.chromium_event.is_none() {
+            write_to_shortraw(&mut shortraw_content, payload_filename, &multi, &mut stats);
+        }
     }
 
     if config.export {

--- a/src/types.rs
+++ b/src/types.rs
@@ -188,7 +188,58 @@ pub struct Stats {
     pub fail_payload_md5: u64,
     pub fail_dynamo_guards_json: u64,
     pub fail_parser: u64,
+    pub fail_key_conflict: u64,
+    pub fail_json_serialization: u64,
     pub unknown: u64,
+}
+
+impl std::fmt::Display for Stats {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut fields = Vec::new();
+
+        if self.ok > 0 {
+            fields.push(format!("ok: {}", self.ok));
+        }
+        if self.other_rank > 0 {
+            fields.push(format!("other_rank: {}", self.other_rank));
+        }
+        if self.fail_glog > 0 {
+            fields.push(format!("fail_glog: {}", self.fail_glog));
+        }
+        if self.fail_json > 0 {
+            fields.push(format!("fail_json: {}", self.fail_json));
+        }
+        if self.fail_payload_md5 > 0 {
+            fields.push(format!("fail_payload_md5: {}", self.fail_payload_md5));
+        }
+        if self.fail_dynamo_guards_json > 0 {
+            fields.push(format!(
+                "fail_dynamo_guards_json: {}",
+                self.fail_dynamo_guards_json
+            ));
+        }
+        if self.fail_parser > 0 {
+            fields.push(format!("fail_parser: {}", self.fail_parser));
+        }
+        if self.fail_key_conflict > 0 {
+            fields.push(format!("fail_key_conflict: {}", self.fail_key_conflict));
+        }
+        if self.fail_json_serialization > 0 {
+            fields.push(format!(
+                "fail_json_serialization: {}",
+                self.fail_json_serialization
+            ));
+        }
+        if self.unknown > 0 {
+            fields.push(format!("unknown: {}", self.unknown));
+        }
+
+        if fields.is_empty() {
+            write!(f, "Stats {{ }}")
+        } else {
+            write!(f, "Stats {{ {} }}", fields.join(", "))
+        }
+    }
 }
 
 #[derive(Debug, Hash, Eq, PartialEq, Deserialize, Serialize, Clone)]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -46,10 +46,7 @@ fn test_parse_simple() {
     );
     let shortraw_content = &map[&PathBuf::from("raw.jsonl")];
     let shortraw_lines = shortraw_content.lines().count();
-    assert_eq!(
-        shortraw_lines, 76,
-        "raw.jsonl should have exactly 76 lines"
-    );
+    assert_eq!(shortraw_lines, 76, "raw.jsonl should have exactly 76 lines");
 }
 
 #[test]
@@ -92,10 +89,7 @@ fn test_parse_compilation_metrics() {
     );
     let shortraw_content = &map[&PathBuf::from("raw.jsonl")];
     let shortraw_lines = shortraw_content.lines().count();
-    assert_eq!(
-        shortraw_lines, 26,
-        "raw.jsonl should have exactly 26 lines"
-    );
+    assert_eq!(shortraw_lines, 26, "raw.jsonl should have exactly 26 lines");
 
     // Check that exactly the expected payload files exist (no more, no less)
     // With conditional payload writing, only payloads not handled by parsers are written
@@ -191,10 +185,7 @@ fn test_parse_compilation_metrics() {
                 }
             }
             Err(e) => {
-                panic!(
-                    "raw.jsonl line is not valid JSON: {} - Error: {}",
-                    line, e
-                );
+                panic!("raw.jsonl line is not valid JSON: {} - Error: {}", line, e);
             }
         }
     }
@@ -209,7 +200,7 @@ fn test_parse_compilation_metrics() {
     assert_eq!(
         payload_filename_count,
         expected_payload_hashes.len(),
-        "Number of payload_filename entries in shortraw.log should match number of payload files"
+        "Number of payload_filename entries in raw.jsonl should match number of payload files"
     );
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -39,14 +39,17 @@ fn test_parse_simple() {
         );
     }
 
-    // Check that raw.jsonl exists and has exactly 76 lines (non-payload lines from original)
+    // Check that raw.jsonl exists and has exactly 26 lines (non-payload lines from original, excluding chromium_event entries)
     assert!(
         map.contains_key(&PathBuf::from("raw.jsonl")),
         "raw.jsonl not found in output"
     );
     let shortraw_content = &map[&PathBuf::from("raw.jsonl")];
     let shortraw_lines = shortraw_content.lines().count();
-    assert_eq!(shortraw_lines, 76, "raw.jsonl should have exactly 76 lines");
+    assert_eq!(
+        shortraw_lines, 26,
+        "raw.jsonl should have exactly 26 lines (excluding 50 chromium_event entries)"
+    );
 }
 
 #[test]


### PR DESCRIPTION
I used these claude code prompts:

- In src/lib.rs there is a main loop demarcated by ' while let Some((lineno, line)) = iter.next()' which processes every line in the input log file.  We currently try to directly parse out the JSON into our structs. I want to also directly re-dump the log line (metadata + JSON) (don't bother parsing it) to a file shortraw.log (analogous to raw.log, which has everything) but do NOT dump the payload. And then I want the payload to go to a folder payloads/HASH.txt (using the has_payload hash as the content-addressed key). Augment a test or two in the existing tests/ to check for the existence of shortraw.log and an appropriate number of lines.
- Let's add a new field to src/parser.rs which is PayloadFile which consists only of a PathBuf. Its semantics are similar to File but we just directly use payload from the log entry; the user doesn't have to specify what the output is. Refactor src/parsers.rs to use this when appropriate by adding a new payload_file_output which doesn't take a payload argument. At minimum StructuredLogParser should be ported to use this but I expect many other parsers should use it too. No new tests are needed, this is a semantics preserving refactor.
- The JSON case in ArtifactParser needs special handling. The output is not quite the same but is morally equivalent to the original. We're going to add a new PayloadReformatFile which has exactly the same behavior as File but expresses this nuance.
- In 8cb2a797afb5c190f1631f42d6a61198e88cc582, we are writing files to payload/....txt. We would now like to only write this file conditionally: if there is a *Payload* in the output, we can use that directly as the payload, instead of having to write one out. Additionally, because the file location can now be unpredictable, we need to insert the filename into the shortraw.log file. Let's do this by putting this into the top level JSON dict: when there is a payload, we will parse it (generically), assert the top level is a dict, and then insert it into "payload_filename" on that dict, and serialize that out.
- Let's simplify the implementation some more by changing shortraw spec. Currently, we replicate the original log line + JSON entirely. Now, I want to make shortraw true JSONL, by incorporating the log line into the JSON payload. The log line information is captured by re_glog and the data parsed into captures. We will put these as equivalently named fields prefixed by "log_" to avoid conflicts with regular payload (we should assert that there is not a conflict with an existing key).  All numeric fields (\d+) should be parsed into integers and stored as JSON number, everything else as strings. Don't include the payload since you already have that info.
- When printing Stats summary at the end, omit fields if they are zero. You'll have to expand the code a bit.
- Rename shortraw.log to raw.jsonl
- When considering what to write to raw.jsonl, exclude JSON entries with chromium_event key set.

Signed-off-by: Edward Yang <ezyang@meta.com>