### PR TITLE
Add --all-ranks CLI infrastructure and core processing logic

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -154,16 +154,20 @@ fn handle_all_ranks(cli: &Cli) -> anyhow::Result<()> {
         .flatten()
         .filter(|entry| {
             let path = entry.path();
-            path.is_file() &&
-            path.file_name()
-                .and_then(|name| name.to_str())
-                .map(|name| name.contains("rank_") && name.ends_with(".log"))
-                .unwrap_or(false)
+            path.is_file()
+                && path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .map(|name| name.contains("rank_") && name.ends_with(".log"))
+                    .unwrap_or(false)
         })
         .collect();
 
     if rank_files.is_empty() {
-        bail!("No rank log files found in directory {}", input_path.display());
+        bail!(
+            "No rank log files found in directory {}",
+            input_path.display()
+        );
     }
 
     let mut rank_links = Vec::new();
@@ -179,12 +183,19 @@ fn handle_all_ranks(cli: &Cli) -> anyhow::Result<()> {
         // Extract rank number from filename
         let rank_num = if let Some(pos) = rank_name.find("rank_") {
             let after_rank = &rank_name[pos + 5..];
-            after_rank.chars().take_while(|c| c.is_ascii_digit()).collect::<String>()
+            after_rank
+                .chars()
+                .take_while(|c| c.is_ascii_digit())
+                .collect::<String>()
         } else {
             "unknown".to_string()
         };
 
-        println!("Processing rank {} from file: {}", rank_num, rank_path.display());
+        println!(
+            "Processing rank {} from file: {}",
+            rank_num,
+            rank_path.display()
+        );
 
         // Create subdirectory for this rank
         let rank_out_dir = out_path.join(format!("rank_{rank_num}"));
@@ -227,7 +238,10 @@ fn handle_all_ranks(cli: &Cli) -> anyhow::Result<()> {
     // Core logic complete - no HTML generation yet
     // TODO - Add landing page HTML generation using template system
 
-    println!("Generated multi-rank report with {} ranks", rank_links.len());
+    println!(
+        "Generated multi-rank report with {} ranks",
+        rank_links.len()
+    );
     println!("Individual rank reports available in:");
     for (rank_num, _) in &rank_links {
         println!("  - rank_{}/index.html", rank_num);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -74,7 +74,7 @@ fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     if cli.all_ranks_html {
-        return handle_all_ranks(&cli);
+        return handle_all_ranks(cli);
     }
 
     let path = if cli.latest {
@@ -159,7 +159,7 @@ fn handle_one_rank(
 }
 
 // handle_all_ranks function with placeholder landing page
-fn handle_all_ranks(cli: &Cli) -> anyhow::Result<()> {
+fn handle_all_ranks(cli: Cli) -> anyhow::Result<()> {
     let input_path = &cli.path;
 
     if !input_path.is_dir() {
@@ -251,7 +251,7 @@ fn handle_all_ranks(cli: &Cli) -> anyhow::Result<()> {
 
         // Create subdirectory for this rank and handle parsing
         let rank_out_dir = out_path.join(format!("rank_{rank_num}"));
-        let main_output_path = handle_one_rank(&rank_path, &rank_out_dir, cli, true)?;
+        let main_output_path = handle_one_rank(&rank_path, &rank_out_dir, &cli, true)?;
 
         // Add link to this rank's page using the actual output path from handle_one_rank
         let rank_link = format!("rank_{}/{}", rank_num, main_output_path.display());

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -206,7 +206,7 @@ fn handle_all_ranks(cli: &Cli) -> anyhow::Result<()> {
                 return false;
             }
 
-            let middle = &filename[5..filename.len()-4]; // Remove "rank_" and ".log"
+            let middle = &filename[5..filename.len() - 4]; // Remove "rank_" and ".log"
             !middle.is_empty() && middle.chars().all(|c| c.is_ascii_digit())
         })
         .collect();
@@ -259,8 +259,12 @@ fn handle_all_ranks(cli: &Cli) -> anyhow::Result<()> {
 
     // Sort rank links by rank number
     rank_links.sort_by(|a, b| {
-        let a_num: i32 = a.0.parse().expect(&format!("Failed to parse rank number from '{}'", a.0));
-        let b_num: i32 = b.0.parse().expect(&format!("Failed to parse rank number from '{}'", b.0));
+        let a_num: i32 =
+            a.0.parse()
+                .expect(&format!("Failed to parse rank number from '{}'", a.0));
+        let b_num: i32 =
+            b.0.parse()
+                .expect(&format!("Failed to parse rank number from '{}'", b.0));
         a_num.cmp(&b_num)
     });
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -187,7 +187,7 @@ fn handle_all_ranks(cli: &Cli) -> anyhow::Result<()> {
         println!("Processing rank {} from file: {}", rank_num, rank_path.display());
 
         // Create subdirectory for this rank
-        let rank_out_dir = out_path.join(format!("rank_{}", rank_num));
+        let rank_out_dir = out_path.join(format!("rank_{rank_num}"));
         fs::create_dir(&rank_out_dir)?;
 
         let config = ParseConfig {
@@ -214,7 +214,7 @@ fn handle_all_ranks(cli: &Cli) -> anyhow::Result<()> {
         }
 
         // Add link to this rank's page
-        rank_links.push((rank_num.clone(), format!("rank_{}/index.html", rank_num)));
+        rank_links.push((rank_num.clone(), format!("rank_{rank_num}/index.html")));
     }
 
     // Sort rank links by rank number
@@ -230,7 +230,7 @@ fn handle_all_ranks(cli: &Cli) -> anyhow::Result<()> {
     println!("Generated multi-rank report with {} ranks", rank_links.len());
     println!("Individual rank reports available in:");
     for (rank_num, _) in &rank_links {
-        println!("  - rank_{}/index.html", rank_num);
+        println!("  - rank_{rank_num}/index.html");
     }
 
     // No browser opening since no landing page yet

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -230,7 +230,7 @@ fn handle_all_ranks(cli: &Cli) -> anyhow::Result<()> {
     println!("Generated multi-rank report with {} ranks", rank_links.len());
     println!("Individual rank reports available in:");
     for (rank_num, _) in &rank_links {
-        println!("  - rank_{rank_num}/index.html");
+        println!("  - rank_{}/index.html", rank_num);
     }
 
     // No browser opening since no landing page yet

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -194,12 +194,20 @@ fn handle_all_ranks(cli: &Cli) -> anyhow::Result<()> {
         .flatten()
         .filter(|entry| {
             let path = entry.path();
-            path.is_file()
-                && path
-                    .file_name()
-                    .and_then(|name| name.to_str())
-                    .map(|name| name.contains("rank_") && name.ends_with(".log"))
-                    .unwrap_or(false)
+            if !path.is_file() {
+                return false;
+            }
+
+            let Some(filename) = path.file_name().and_then(|name| name.to_str()) else {
+                return false;
+            };
+
+            if !filename.starts_with("rank_") || !filename.ends_with(".log") {
+                return false;
+            }
+
+            let middle = &filename[5..filename.len()-4]; // Remove "rank_" and ".log"
+            !middle.is_empty() && middle.chars().all(|c| c.is_ascii_digit())
         })
         .collect();
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -78,7 +78,7 @@ fn main() -> anyhow::Result<()> {
     }
 
     let path = if cli.latest {
-        let input_path = cli.path;
+        let input_path = &cli.path;
         // Path should be a directory
         if !input_path.is_dir() {
             bail!(
@@ -87,7 +87,7 @@ fn main() -> anyhow::Result<()> {
             );
         }
 
-        let last_modified_file = std::fs::read_dir(&input_path)
+        let last_modified_file = std::fs::read_dir(input_path)
             .with_context(|| format!("Couldn't access directory {}", input_path.display()))?
             .flatten()
             .filter(|f| f.metadata().unwrap().is_file())
@@ -98,33 +98,14 @@ fn main() -> anyhow::Result<()> {
         };
         last_modified_file.path()
     } else {
-        cli.path
+        cli.path.clone()
     };
 
-    let out_path = cli.out;
+    let out_path = cli.out.clone();
     setup_output_directory(&out_path, cli.overwrite)?;
 
-    let config = ParseConfig {
-        strict: cli.strict,
-        strict_compile_id: cli.strict_compile_id,
-        custom_parsers: Vec::new(),
-        custom_header_html: cli.custom_header_html.clone(),
-        verbose: cli.verbose,
-        plain_text: cli.plain_text,
-        export: cli.export,
-        inductor_provenance: cli.inductor_provenance,
-        all_ranks: cli.all_ranks_html,
-    };
-
-    let output = parse_path(&path, config)?;
-
-    for (filename, path) in output {
-        let out_file = out_path.join(filename);
-        if let Some(dir) = out_file.parent() {
-            fs::create_dir_all(dir)?;
-        }
-        fs::write(out_file, path)?;
-    }
+    // Use handle_one_rank for single rank processing (don't create directory since it already exists)
+    handle_one_rank(&path, &out_path, &cli, false)?;
 
     if !cli.no_browser {
         opener::open(out_path.join("index.html"))?;
@@ -138,8 +119,11 @@ fn handle_one_rank(
     rank_path: &PathBuf,
     rank_out_dir: &PathBuf,
     cli: &Cli,
+    create_output_dir: bool,
 ) -> anyhow::Result<PathBuf> {
-    fs::create_dir(rank_out_dir)?;
+    if create_output_dir {
+        fs::create_dir(rank_out_dir)?;
+    }
 
     let config = ParseConfig {
         strict: cli.strict,
@@ -157,7 +141,7 @@ fn handle_one_rank(
 
     let mut main_output_path = None;
 
-    // Write output files to rank subdirectory
+    // Write output files to output directory
     for (filename, content) in output {
         let out_file = rank_out_dir.join(&filename);
         if let Some(dir) = out_file.parent() {
@@ -203,7 +187,9 @@ fn handle_all_ranks(cli: &Cli) -> anyhow::Result<()> {
             };
 
             // Only support PyTorch TORCH_TRACE files: dedicated_log_torch_trace_rank_0_hash.log
-            if !filename.starts_with("dedicated_log_torch_trace_rank_") || !filename.ends_with(".log") {
+            if !filename.starts_with("dedicated_log_torch_trace_rank_")
+                || !filename.ends_with(".log")
+            {
                 return false;
             }
 
@@ -236,19 +222,26 @@ fn handle_all_ranks(cli: &Cli) -> anyhow::Result<()> {
             .unwrap_or("unknown");
 
         // Extract rank number from PyTorch TORCH_TRACE filename
-        let rank_num = if let Some(after_prefix) = rank_name.strip_prefix("dedicated_log_torch_trace_rank_") {
-            if let Some(underscore_pos) = after_prefix.find('_') {
-                let rank_part = &after_prefix[..underscore_pos];
-                if rank_part.is_empty() || !rank_part.chars().all(|c| c.is_ascii_digit()) {
-                    bail!("Could not extract rank number from TORCH_TRACE filename: {}", rank_name);
+        let rank_num =
+            if let Some(after_prefix) = rank_name.strip_prefix("dedicated_log_torch_trace_rank_") {
+                if let Some(underscore_pos) = after_prefix.find('_') {
+                    let rank_part = &after_prefix[..underscore_pos];
+                    if rank_part.is_empty() || !rank_part.chars().all(|c| c.is_ascii_digit()) {
+                        bail!(
+                            "Could not extract rank number from TORCH_TRACE filename: {}",
+                            rank_name
+                        );
+                    }
+                    rank_part.to_string()
+                } else {
+                    bail!("Invalid TORCH_TRACE filename format: {}", rank_name);
                 }
-                rank_part.to_string()
             } else {
-                bail!("Invalid TORCH_TRACE filename format: {}", rank_name);
-            }
-        } else {
-            bail!("Filename does not match PyTorch TORCH_TRACE pattern: {}", rank_name);
-        };
+                bail!(
+                    "Filename does not match PyTorch TORCH_TRACE pattern: {}",
+                    rank_name
+                );
+            };
 
         println!(
             "Processing rank {} from file: {}",
@@ -258,10 +251,10 @@ fn handle_all_ranks(cli: &Cli) -> anyhow::Result<()> {
 
         // Create subdirectory for this rank and handle parsing
         let rank_out_dir = out_path.join(format!("rank_{rank_num}"));
-        let main_output_path = handle_one_rank(&rank_path, &rank_out_dir, cli)?;
+        let main_output_path = handle_one_rank(&rank_path, &rank_out_dir, cli, true)?;
 
-        // Add link to this rank's page using the actual output path
-        let rank_link = format!("rank_{rank_num}/{}", main_output_path.display());
+        // Add link to this rank's page using the actual output path from handle_one_rank
+        let rank_link = format!("rank_{}/{}", rank_num, main_output_path.display());
         rank_links.push((rank_num.clone(), rank_link));
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub struct ParseConfig {
     pub plain_text: bool,
     pub export: bool,
     pub inductor_provenance: bool,
+    pub all_ranks: bool,
 }
 
 impl Default for ParseConfig {
@@ -43,6 +44,7 @@ impl Default for ParseConfig {
             plain_text: false,
             export: false,
             inductor_provenance: false,
+            all_ranks: false,
         }
     }
 }


### PR DESCRIPTION
Summary:

- Implements functionality for processing multiple rank log files with new --all-ranks flag 
- Core Processing Logic: handle_all_ranks() function for multi rank processing

Future work:
- landing page HTML generation and template system integration
