### PR TITLE
refactor: Extract handle_one_rank helper function

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,6 +6,9 @@ use std::path::PathBuf;
 
 use tlparse::{parse_path, ParseConfig};
 
+// Main output filename used by both single rank and multi-rank processing
+const MAIN_OUTPUT_FILENAME: &str = "index.html";
+
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 #[command(propagate_version = true)]
@@ -51,8 +54,9 @@ pub struct Cli {
 
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
+
     let path = if cli.latest {
-        let input_path = cli.path;
+        let input_path = &cli.path;
         // Path should be a directory
         if !input_path.is_dir() {
             bail!(
@@ -72,11 +76,10 @@ fn main() -> anyhow::Result<()> {
         };
         last_modified_file.path()
     } else {
-        cli.path
+        cli.path.clone()
     };
 
-    let out_path = cli.out;
-
+    let out_path = cli.out.clone();
     if out_path.exists() {
         if !cli.overwrite {
             bail!(
@@ -86,31 +89,51 @@ fn main() -> anyhow::Result<()> {
         }
         fs::remove_dir_all(&out_path)?;
     }
-    fs::create_dir(&out_path)?;
 
+    // Use handle_one_rank for single rank processing
+    handle_one_rank(&path, &out_path, &cli)?;
+
+    if !cli.no_browser {
+        opener::open(out_path.join(MAIN_OUTPUT_FILENAME))?;
+    }
+    Ok(())
+}
+
+// Helper function to handle parsing and writing output for a single rank
+// Returns the relative path to the main output file within the rank directory
+fn handle_one_rank(
+    rank_path: &PathBuf,
+    rank_out_dir: &PathBuf,
+    cli: &Cli,
+) -> anyhow::Result<PathBuf> {
     let config = ParseConfig {
         strict: cli.strict,
         strict_compile_id: cli.strict_compile_id,
         custom_parsers: Vec::new(),
-        custom_header_html: cli.custom_header_html,
+        custom_header_html: cli.custom_header_html.clone(),
         verbose: cli.verbose,
         plain_text: cli.plain_text,
         export: cli.export,
         inductor_provenance: cli.inductor_provenance,
     };
 
-    let output = parse_path(&path, config)?;
+    let output = parse_path(rank_path, config)?;
 
-    for (filename, path) in output {
-        let out_file = out_path.join(filename);
+    let mut main_output_path = None;
+
+    // Write output files to output directory
+    for (filename, content) in output {
+        let out_file = rank_out_dir.join(&filename);
         if let Some(dir) = out_file.parent() {
             fs::create_dir_all(dir)?;
         }
-        fs::write(out_file, path)?;
+        fs::write(out_file, content)?;
+
+        // Track the main output file (typically index.html)
+        if filename.file_name().and_then(|name| name.to_str()) == Some(MAIN_OUTPUT_FILENAME) {
+            main_output_path = Some(filename);
+        }
     }
 
-    if !cli.no_browser {
-        opener::open(out_path.join("index.html"))?;
-    }
-    Ok(())
+    Ok(main_output_path.unwrap_or_else(|| PathBuf::from(MAIN_OUTPUT_FILENAME)))
 }


### PR DESCRIPTION
Summary:

- Extract single-rank parsing logic into reusable handle_one_rank function
- Introduce MAIN_OUTPUT_FILENAME constant to replace hardcoded 'index.html'