### PR TITLE
Add --all-ranks-html CLI infrastructure and core processing logic

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,9 +6,6 @@ use std::path::PathBuf;
 
 use tlparse::{parse_path, ParseConfig};
 
-// Main output filename used by both single rank and multi-rank processing
-const MAIN_OUTPUT_FILENAME: &str = "index.html";
-
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 #[command(propagate_version = true)]
@@ -54,7 +51,6 @@ pub struct Cli {
 
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
-
     let path = if cli.latest {
         let input_path = cli.path;
         // Path should be a directory
@@ -80,6 +76,7 @@ fn main() -> anyhow::Result<()> {
     };
 
     let out_path = cli.out;
+
     if out_path.exists() {
         if !cli.overwrite {
             bail!(
@@ -103,10 +100,10 @@ fn main() -> anyhow::Result<()> {
         inductor_provenance: cli.inductor_provenance,
     };
     let per_rank_config = config;
-    parse_and_write_output(per_rank_config, &path, &out_path)?;
+    let main_output_file = parse_and_write_output(per_rank_config, &path, &out_path);
 
     if !cli.no_browser {
-        opener::open(out_path.join(MAIN_OUTPUT_FILENAME))?;
+        opener::open(main_output_file.unwrap())?;
     }
     Ok(())
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -89,8 +89,9 @@ fn main() -> anyhow::Result<()> {
         }
         fs::remove_dir_all(&out_path)?;
     }
+    fs::create_dir(&out_path)?;
 
-    // Use handle_one_rank for single rank processing
+    // Parse log file and write output
     let config = ParseConfig {
         strict: cli.strict,
         strict_compile_id: cli.strict_compile_id,
@@ -110,12 +111,12 @@ fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-// Helper function to handle parsing and writing output for a single rank
-// Returns the relative path to the main output file within the rank directory
+// Helper function to parse a log file and write output to a directory
+// Returns the relative path to the main output file within the output directory
 fn parse_and_write_output(
     config: ParseConfig,
-    path: &PathBuf,
-    rank_out_dir: &PathBuf,
+    log_path: &PathBuf,
+    output_dir: &PathBuf,
 ) -> anyhow::Result<PathBuf> {
     let config = ParseConfig {
         strict: cli.strict,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,6 +47,9 @@ pub struct Cli {
     /// For inductor provenance tracking highlighter
     #[arg(short, long)]
     inductor_provenance: bool,
+    /// Parse all ranks and create a unified multi-rank report
+    #[arg(long)]
+    all_ranks_html: bool,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -93,25 +96,46 @@ fn main() -> anyhow::Result<()> {
         strict: cli.strict,
         strict_compile_id: cli.strict_compile_id,
         custom_parsers: Vec::new(),
-        custom_header_html: cli.custom_header_html,
+        custom_header_html: cli.custom_header_html.clone(),
         verbose: cli.verbose,
         plain_text: cli.plain_text,
         export: cli.export,
         inductor_provenance: cli.inductor_provenance,
     };
-    let per_rank_config = config;
-    let main_output_file = parse_and_write_output(per_rank_config, &path, &out_path);
 
-    if !cli.no_browser {
-        opener::open(main_output_file.unwrap())?;
+    if cli.all_ranks_html {
+        handle_all_ranks(path, out_path, cli.overwrite, &config)?;
+    } else {
+        handle_one_rank(
+            &config,
+            path,
+            cli.latest,
+            out_path,
+            !cli.no_browser,
+            cli.overwrite,
+        )?;
     }
     Ok(())
 }
 
-// Helper function to parse a log file and write output to a directory
-// Returns the relative path to the main output file within the output directory
+/// Create the output directory
+fn setup_output_directory(out_path: &PathBuf, overwrite: bool) -> anyhow::Result<()> {
+    if out_path.exists() {
+        if !overwrite {
+            bail!(
+                "Directory {} already exists; pass --overwrite to replace it or use -o OUTDIR",
+                out_path.display()
+            );
+        }
+        fs::remove_dir_all(&out_path)?;
+    }
+    fs::create_dir_all(&out_path)?;
+    Ok(())
+}
+
+/// Parse a log file and write the rendered artefacts into `output_dir`.
 fn parse_and_write_output(
-    config: ParseConfig,
+    config: &ParseConfig,
     log_path: &PathBuf,
     output_dir: &PathBuf,
 ) -> anyhow::Result<PathBuf> {
@@ -143,7 +167,6 @@ fn parse_and_write_output(
 ) -> anyhow::Result<PathBuf> {
     let output = parse_path(log_path, config)?;
 
-    // Write output files to output directory
     for (filename, content) in output {
         let out_path = output_dir.join(&filename);
         if let Some(dir) = out_path.parent() {
@@ -152,4 +175,91 @@ fn parse_and_write_output(
         fs::write(out_path, content)?;
     }
     Ok(output_dir.join("index.html"))
+}
+
+fn handle_one_rank(
+    cfg: &ParseConfig,
+    input_path: PathBuf,
+    latest: bool,
+    out_dir: PathBuf,
+    open_browser: bool,
+    overwrite: bool,
+) -> anyhow::Result<()> {
+    // Resolve which log file we should parse
+    let log_path = if latest {
+        if !input_path.is_dir() {
+            bail!(
+                "Input path {} is not a directory (required with --latest)",
+                input_path.display()
+            );
+        }
+        std::fs::read_dir(input_path)?
+            .flatten()
+            .filter(|e| e.metadata().ok().map_or(false, |m| m.is_file()))
+            .max_by_key(|e| e.metadata().unwrap().modified().unwrap())
+            .map(|e| e.path())
+            .context("No files found in directory for --latest")?
+    } else {
+        input_path.clone()
+    };
+
+    setup_output_directory(&out_dir, overwrite)?;
+    let main_output_file = parse_and_write_output(cfg, &log_path, &out_dir)?;
+
+    if open_browser {
+        opener::open(out_dir.join(main_output_file))?;
+    }
+    Ok(())
+}
+
+fn handle_all_ranks(path: PathBuf, out_path: PathBuf, overwrite: bool, cfg: &ParseConfig) -> anyhow::Result<()> {
+    let input_dir = path;
+    if !input_dir.is_dir() {
+        bail!(
+            "Input path {} must be a directory when using --all-ranks-html",
+            input_dir.display()
+        );
+    }
+
+    setup_output_directory(&out_path, overwrite)?;
+
+    // Discover rank log files
+    let rank_logs: Vec<_> = std::fs::read_dir(&input_dir)?
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            if !path.is_file() {
+                return None;
+            }
+            let filename = path.file_name()?.to_str()?;
+            let after_prefix = filename.strip_prefix("dedicated_log_torch_trace_rank_")?;
+            let without_log = after_prefix.strip_suffix(".log")?;
+            let rank_part = without_log.split('_').next()?;
+            rank_part
+                .chars()
+                .all(|c| c.is_ascii_digit())
+                .then(|| (path.clone(), rank_part.to_owned()))
+        })
+        .collect();
+
+    if rank_logs.is_empty() {
+        bail!(
+            "No rank log files found in directory {}",
+            input_dir.display()
+        );
+    }
+
+    for (log_path, rank_num) in rank_logs {
+        let subdir = out_path.join(format!("rank_{rank_num}"));
+        println!("Processing rank {rank_num} → {}", subdir.display());
+
+        handle_one_rank(cfg, log_path, false, subdir, false, false)?;
+    }
+
+    println!(
+        "Multi-rank report generated under {}\nIndividual pages: rank_*/index.html",
+        out_path.display()
+    );
+    // TODO: generate and open a landing page
+    Ok(())
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,6 +6,9 @@ use std::path::PathBuf;
 
 use tlparse::{parse_path, ParseConfig};
 
+// Main output filename used by both single rank and multi-rank processing
+const MAIN_OUTPUT_FILENAME: &str = "index.html";
+
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 #[command(propagate_version = true)]
@@ -51,8 +54,9 @@ pub struct Cli {
 
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
+
     let path = if cli.latest {
-        let input_path = cli.path;
+        let input_path = &cli.path;
         // Path should be a directory
         if !input_path.is_dir() {
             bail!(
@@ -72,11 +76,10 @@ fn main() -> anyhow::Result<()> {
         };
         last_modified_file.path()
     } else {
-        cli.path
+        cli.path.clone()
     };
 
-    let out_path = cli.out;
-
+    let out_path = cli.out.clone();
     if out_path.exists() {
         if !cli.overwrite {
             bail!(
@@ -86,13 +89,28 @@ fn main() -> anyhow::Result<()> {
         }
         fs::remove_dir_all(&out_path)?;
     }
-    fs::create_dir(&out_path)?;
 
+    // Use handle_one_rank for single rank processing
+    handle_one_rank(&path, &out_path, &cli)?;
+
+    if !cli.no_browser {
+        opener::open(out_path.join(MAIN_OUTPUT_FILENAME))?;
+    }
+    Ok(())
+}
+
+// Helper function to handle parsing and writing output for a single rank
+// Returns the relative path to the main output file within the rank directory
+fn handle_one_rank(
+    rank_path: &PathBuf,
+    rank_out_dir: &PathBuf,
+    cli: &Cli,
+) -> anyhow::Result<PathBuf> {
     let config = ParseConfig {
         strict: cli.strict,
         strict_compile_id: cli.strict_compile_id,
         custom_parsers: Vec::new(),
-        custom_header_html: cli.custom_header_html,
+        custom_header_html: cli.custom_header_html.clone(),
         verbose: cli.verbose,
         plain_text: cli.plain_text,
         export: cli.export,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -665,8 +665,9 @@ pub fn parse_path(path: &PathBuf, config: &ParseConfig) -> anyhow::Result<ParseO
         let default_parsers = default_parsers(&tt, config);
         let mut all_parsers: Vec<&Box<dyn StructuredLogParser>> = default_parsers.iter().collect();
         all_parsers.extend(config.custom_parsers.iter());
+        let mut parser_payload_filename = ParserResult::NoPayload;
         for parser in all_parsers {
-            run_parser(
+            let result = run_parser(
                 lineno,
                 parser,
                 &e,


### PR DESCRIPTION
Summary:

New CLI flag: --all-ranks-html enables multi-rank processing mode for unified HTML landing
Unified output structure: Creates separate rank_N/ subdirectories with individual HTML reports
Code refactoring: Extracted reusable functions handle_one_rank, setup_output_directory,parse_and_write_output