### PR TITLE
Placeholder desync warning message on TLParse Landing Page

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1189,6 +1189,7 @@ pub fn generate_multi_rank_html(
         ranks: sorted_ranks,
         qps: TEMPLATE_QUERY_PARAM_SCRIPT,
         has_chromium_events,
+        show_desync_warning: true, // placeholder for future condition
     };
     let html = tt.render("multi_rank_index.html", &ctx)?;
     let landing_page_path = out_path.join("index.html");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1189,7 +1189,7 @@ pub fn generate_multi_rank_html(
         ranks: sorted_ranks,
         qps: TEMPLATE_QUERY_PARAM_SCRIPT,
         has_chromium_events,
-        show_desync_warning: true, // placeholder for future condition
+        show_desync_warning: false, // placeholder for future condition
     };
     let html = tt.render("multi_rank_index.html", &ctx)?;
     let landing_page_path = out_path.join("index.html");

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -24,6 +24,12 @@ summary::-webkit-details-marker { color: #00ACF3; font-size: 125%; margin-right:
 summary:focus { outline-style: none; }
 article > details > summary { font-size: 28px; margin-top: 16px; }
 details > p { margin-left: 24px; }
+        .warning-box {
+            background-color:rgb(249, 178, 178);
+            border: 1px solidrgb(251, 251, 251);
+            padding: 12px 16px;
+            margin: 16px 0;
+        }
 details details summary { font-size: 16px; }
 "#;
 
@@ -541,6 +547,11 @@ pub static TEMPLATE_MULTI_RANK_INDEX: &str = r#"
 <body>
 <div>
 {custom_header_html | format_unescaped}
+{{ if show_desync_warning }}
+<div class="warning-box">
+    <p><strong>Warning:</strong> Placeholder desync warning message.</p>
+</div>
+{{ endif }}
 <h2>Multi-Rank TLParse Report</h2>
 <p>
 This report contains TLParse links from <strong>{num_ranks}</strong> rank(s). Click on any rank below

--- a/src/types.rs
+++ b/src/types.rs
@@ -841,4 +841,5 @@ pub struct MultiRankContext<'a> {
     pub ranks: Vec<String>,
     pub qps: &'a str,
     pub has_chromium_events: bool,
+    pub show_desync_warning: bool,
 }


### PR DESCRIPTION
Basic Placeholder desync warning banner on TLParse Landing Page

In future, will use this component to display desync warnings.

<img width="1317" height="575" alt="image" src="https://github.com/user-attachments/assets/190e7281-c12b-4c4e-bc83-600515af2bdb" />
