### PR TITLE
Add Chromium trace for runtime estimates (per-graph threads, per-rank processes)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1187,7 +1187,6 @@ pub fn generate_multi_rank_html(
     has_cache_divergence: bool,
     has_collective_divergence: bool,
     runtime_analysis: Option<RuntimeAnalysis>,
-    runtime_analysis: Option<RuntimeAnalysis>,
     has_runtime_trace: bool,
 ) -> anyhow::Result<(PathBuf, String)> {
     // Create the TinyTemplate instance for rendering the landing page.
@@ -1208,7 +1207,6 @@ pub fn generate_multi_rank_html(
         compile_id_divergence,
         has_cache_divergence,
         has_collective_divergence,
-        runtime_analysis,
         runtime_analysis,
         has_runtime_trace,
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,8 @@ mod templates;
 mod types;
 
 pub use types::{
-    DivergenceGroup, GraphAnalysis, GraphRuntime, RankMetaData, RuntimeAnalysis, RuntimeRankDetail,
+    ArtifactFlags, Diagnostics, DivergenceFlags, DivergenceGroup, GraphAnalysis, GraphRuntime,
+    RankMetaData, RuntimeAnalysis, RuntimeRankDetail,
 };
 
 #[derive(Debug)]
@@ -1184,10 +1185,7 @@ pub fn generate_multi_rank_html(
     cache_divergence_groups: Vec<DivergenceGroup>,
     collective_divergence_groups: Vec<DivergenceGroup>,
     compile_id_divergence: bool,
-    has_cache_divergence: bool,
-    has_collective_divergence: bool,
-    runtime_analysis: Option<RuntimeAnalysis>,
-    has_runtime_trace: bool,
+    diagnostics: Diagnostics,
 ) -> anyhow::Result<(PathBuf, String)> {
     // Create the TinyTemplate instance for rendering the landing page.
     let mut tt = TinyTemplate::new();
@@ -1205,10 +1203,7 @@ pub fn generate_multi_rank_html(
         cache_divergence_groups,
         collective_divergence_groups,
         compile_id_divergence,
-        has_cache_divergence,
-        has_collective_divergence,
-        runtime_analysis,
-        has_runtime_trace,
+        diagnostics,
     };
     let html = tt.render("multi_rank_index.html", &ctx)?;
     let landing_page_path = out_path.join("index.html");

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -687,7 +687,7 @@ pub fn read_runtime_estimations(
     read_artifacts(
         out_path,
         rank_nums,
-        "inductor_tlparse_runtime",
+        "inductor_runtime_and_tensor_meta",
         |content, rank, graph| {
             #[derive(serde::Deserialize)]
             struct RuntimeJson {

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -552,7 +552,7 @@ pub static TEMPLATE_MULTI_RANK_INDEX: &str = r#"
     {{ if compile_id_divergence }}
     <p><strong>Warning:</strong> Diverging Compilation IDs detected across ranks. This may lead to hangs or timeouts during distributed execution.</p>
     {{ endif }}
-    {{ if has_cache_divergence }}
+    {{ if diagnostics.divergence.cache }}
     <p><strong>Warning:</strong> Diverging Cache hit/miss patterns detected across ranks. Cache hit/miss pattern groups:</p>
     <ul>
         {{ for group in cache_divergence_groups }}
@@ -560,7 +560,7 @@ pub static TEMPLATE_MULTI_RANK_INDEX: &str = r#"
         {{ endfor }}
     </ul>
     {{ endif }}
-    {{ if has_collective_divergence }}
+    {{ if diagnostics.divergence.collective }}
     <p><strong>Warning:</strong> Diverging collective operation sequences detected across ranks. This can lead to hangs or timeouts during distributed execution.</p>
     <p>Collective operation sequence groups:</p>
     <ul>
@@ -584,7 +584,7 @@ You can download and view them in a tool like <a href='https://ui.perfetto.dev/'
 This is a combined trace from all ranks.
 </p>
 {{ endif }}
-{{ if has_runtime_trace }}
+{{ if diagnostics.artifacts.runtime_trace }}
 <h3> Runtime Trace Visualization </h3>
 <p>
 <a href='chromium_trace_with_runtime.json'>Runtime Estimation Chromium Trace</a> shows estimated runtime per operation across all ranks and graphs.
@@ -600,8 +600,8 @@ Individual rank reports:
     <li><a href="rank_{rank}/index.html">Rank {rank}</a></li>
 {{ endfor }}
 </ul>
-{{ if runtime_analysis }}
-{{ if runtime_analysis.has_mismatched_graph_counts }}
+{{ if diagnostics.analysis }}
+{{ if diagnostics.analysis.has_mismatched_graph_counts }}
 <h3>Graph Runtime Analysis</h3>
 <p>
 <strong>Runtime analysis not available:</strong> Ranks have different numbers of compiled graphs, preventing cross-rank comparison. This mismatch may indicate compilation divergence between ranks.
@@ -613,7 +613,7 @@ Runtime variance analysis across all <strong>{num_ranks}</strong> rank(s) for ea
 helping identify performance imbalances that could impact distributed training efficiency. Large deltas indicate potential
 desync issues on specific ranks.
 </p>
-{{ for graph in runtime_analysis.graphs }}
+{{ for graph in diagnostics.analysis.graphs }}
 <p><strong>Graph {graph.graph_id}:</strong> {graph.delta_ms} ms delta (Fastest: Rank {graph.rank_details.0.rank} - {graph.rank_details.0.runtime_ms} ms, Slowest: Rank {graph.rank_details.1.rank} - {graph.rank_details.1.runtime_ms} ms)</p>
 {{ endfor }}
 {{ endif }}

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -606,7 +606,7 @@ helping identify performance imbalances that could impact distributed training e
 desync issues on specific ranks.
 </p>
 {{ for graph in runtime_analysis.graphs }}
-<p><strong>Graph {graph.graph_id}:</strong> {graph.delta_ms} ms delta (Fastest: Rank {graph.rank_details.0.rank} - {graph.rank_details.0.runtime_ms} ms, Slowest: Rank {graph.rank_details.1.rank} - {graph.rank_details.1.runtime_ms} ms)</p>
+<p><strong>Graph {graph.rank_details.0.graph_id}:</strong> {graph.delta_ms} ms delta (Fastest: Rank {graph.rank_details.0.rank} - {graph.rank_details.0.runtime_ms} ms, Slowest: Rank {graph.rank_details.1.rank} - {graph.rank_details.1.runtime_ms} ms)</p>
 {{ endfor }}
 {{ endif }}
 {{ endif }}

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -584,6 +584,14 @@ You can download and view them in a tool like <a href='https://ui.perfetto.dev/'
 This is a combined trace from all ranks.
 </p>
 {{ endif }}
+{{ if has_runtime_trace }}
+<h3> Runtime Trace Visualization </h3>
+<p>
+<a href='chromium_trace_with_runtime.json'>Runtime Estimation Chromium Trace</a> shows estimated runtime per operation across all ranks and graphs.
+Each rank appears as a separate process (PID) in the trace; within each process, each compiled graph is visualized as its own thread (TID). Operations are laid out sequentially by estimated duration on that thread.
+You can download and view this trace in <a href='https://ui.perfetto.dev/'>Perfetto</a> to visualize performance differences across ranks.
+</p>
+{{ endif }}
 <p>
 Individual rank reports:
 </p>
@@ -606,7 +614,7 @@ helping identify performance imbalances that could impact distributed training e
 desync issues on specific ranks.
 </p>
 {{ for graph in runtime_analysis.graphs }}
-<p><strong>Graph {graph.rank_details.0.graph_id}:</strong> {graph.delta_ms} ms delta (Fastest: Rank {graph.rank_details.0.rank} - {graph.rank_details.0.runtime_ms} ms, Slowest: Rank {graph.rank_details.1.rank} - {graph.rank_details.1.runtime_ms} ms)</p>
+<p><strong>Graph {graph.graph_id}:</strong> {graph.delta_ms} ms delta (Fastest: Rank {graph.rank_details.0.rank} - {graph.rank_details.0.runtime_ms} ms, Slowest: Rank {graph.rank_details.1.rank} - {graph.rank_details.1.runtime_ms} ms)</p>
 {{ endfor }}
 {{ endif }}
 {{ endif }}

--- a/src/types.rs
+++ b/src/types.rs
@@ -61,14 +61,14 @@ pub struct GraphRuntime {
 }
 
 /// Details for a specific rank at a graph index
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct RuntimeRankDetail {
     pub rank: u32,
     pub runtime_ms: f64,
 }
 
 /// Analysis results for a single graph index across all ranks
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct GraphAnalysis {
     pub graph_index: usize,
     pub graph_id: String,
@@ -77,7 +77,7 @@ pub struct GraphAnalysis {
 }
 
 /// Runtime analysis results across ranks for all graphs
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct RuntimeAnalysis {
     pub graphs: Vec<GraphAnalysis>,
     pub has_mismatched_graph_counts: bool,
@@ -893,6 +893,24 @@ pub struct ProvenanceContext<'a> {
     pub node_mappings_content: String,
 }
 
+#[derive(Debug, Clone, Copy, Default, serde::Serialize, serde::Deserialize)]
+pub struct DivergenceFlags {
+    pub cache: bool,
+    pub collective: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default, serde::Serialize, serde::Deserialize)]
+pub struct ArtifactFlags {
+    pub runtime_trace: bool,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct Diagnostics {
+    pub divergence: DivergenceFlags,
+    pub artifacts: ArtifactFlags,
+    pub analysis: Option<RuntimeAnalysis>,
+}
+
 #[derive(Serialize)]
 pub struct MultiRankContext<'a> {
     pub css: &'a str,
@@ -905,8 +923,5 @@ pub struct MultiRankContext<'a> {
     pub cache_divergence_groups: Vec<DivergenceGroup>,
     pub collective_divergence_groups: Vec<DivergenceGroup>,
     pub compile_id_divergence: bool,
-    pub has_cache_divergence: bool,
-    pub has_collective_divergence: bool,
-    pub runtime_analysis: Option<RuntimeAnalysis>,
-    pub has_runtime_trace: bool,
+    pub diagnostics: Diagnostics,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -908,4 +908,5 @@ pub struct MultiRankContext<'a> {
     pub has_cache_divergence: bool,
     pub has_collective_divergence: bool,
     pub runtime_analysis: Option<RuntimeAnalysis>,
+    pub has_runtime_trace: bool,
 }

--- a/tests/inputs/multi_rank_runtime/dedicated_log_torch_trace_rank_0.log
+++ b/tests/inputs/multi_rank_runtime/dedicated_log_torch_trace_rank_0.log
@@ -1683,7 +1683,7 @@ V0804 12:34:15.353000 1142857 torch/_inductor/debug.py:700] {"artifact": {"name"
 	"torch.ops._c10d_functional.all_reduce_.default",
 	"torch.ops._c10d_functional.wait_tensor.default"
 	]
-V0804 12:34:15.456000 1142857 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_tlparse_runtime", "encoding": "json"}, "rank": 0, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "114d64567a1ab3e037f77ad8fb9055c2"}
+V0804 12:34:15.456000 1142857 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_runtime_and_tensor_meta", "encoding": "json"}, "rank": 0, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "114d64567a1ab3e037f77ad8fb9055c2"}
 	{
 	"ops": [
 	{
@@ -5432,7 +5432,7 @@ V0804 12:34:17.546000 1142857 torch/_inductor/debug.py:700] {"artifact": {"name"
 	"torch.ops._c10d_functional.wait_tensor.default",
 	"torch.ops._c10d_functional.wait_tensor.default"
 	]
-V0804 12:34:17.554000 1142857 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_tlparse_runtime", "encoding": "json"}, "rank": 0, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "5bdf44b46ade21759085f713237b436d"}
+V0804 12:34:17.554000 1142857 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_runtime_and_tensor_meta", "encoding": "json"}, "rank": 0, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "5bdf44b46ade21759085f713237b436d"}
 	{
 	"ops": [
 	{
@@ -9255,7 +9255,7 @@ V0804 12:34:17.546000 1142857 torch/_inductor/debug.py:700] {"artifact": {"name"
 	"torch.ops._c10d_functional.wait_tensor.default",
 	"torch.ops._c10d_functional.wait_tensor.default"
 	]
-V0804 12:34:17.554000 1142857 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_tlparse_runtime", "encoding": "json"}, "rank": 0, "frame_id": 0, "frame_compile_id": 2, "attempt": 0, "has_payload": "5bdf44b46ade21759085f713237b436d"}
+V0804 12:34:17.554000 1142857 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_runtime_and_tensor_meta", "encoding": "json"}, "rank": 0, "frame_id": 0, "frame_compile_id": 2, "attempt": 0, "has_payload": "5bdf44b46ade21759085f713237b436d"}
 	{
 	"ops": [
 	{
@@ -13078,7 +13078,7 @@ V0804 12:34:17.546000 1142857 torch/_inductor/debug.py:700] {"artifact": {"name"
 	"torch.ops._c10d_functional.wait_tensor.default",
 	"torch.ops._c10d_functional.wait_tensor.default"
 	]
-V0804 12:34:17.554000 1142857 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_tlparse_runtime", "encoding": "json"}, "rank": 0, "frame_id": 0, "frame_compile_id": 3, "attempt": 0, "has_payload": "5bdf44b46ade21759085f713237b436d"}
+V0804 12:34:17.554000 1142857 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_runtime_and_tensor_meta", "encoding": "json"}, "rank": 0, "frame_id": 0, "frame_compile_id": 3, "attempt": 0, "has_payload": "5bdf44b46ade21759085f713237b436d"}
 	{
 	"ops": [
 	{

--- a/tests/inputs/multi_rank_runtime/dedicated_log_torch_trace_rank_1.log
+++ b/tests/inputs/multi_rank_runtime/dedicated_log_torch_trace_rank_1.log
@@ -1683,7 +1683,7 @@ V0804 12:34:15.202000 1142858 torch/_inductor/debug.py:700] {"artifact": {"name"
 	"torch.ops._c10d_functional.all_reduce_.default",
 	"torch.ops._c10d_functional.wait_tensor.default"
 	]
-V0804 12:34:15.305000 1142858 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_tlparse_runtime", "encoding": "json"}, "rank": 1, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "114d64567a1ab3e037f77ad8fb9055c2"}
+V0804 12:34:15.305000 1142858 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_runtime_and_tensor_meta", "encoding": "json"}, "rank": 1, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "114d64567a1ab3e037f77ad8fb9055c2"}
 	{
 	"ops": [
 	{
@@ -5432,7 +5432,7 @@ V0804 12:34:17.528000 1142858 torch/_inductor/debug.py:700] {"artifact": {"name"
 	"torch.ops._c10d_functional.wait_tensor.default",
 	"torch.ops._c10d_functional.wait_tensor.default"
 	]
-V0804 12:34:17.536000 1142858 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_tlparse_runtime", "encoding": "json"}, "rank": 1, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "5bdf44b46ade21759085f713237b436d"}
+V0804 12:34:17.536000 1142858 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_runtime_and_tensor_meta", "encoding": "json"}, "rank": 1, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "5bdf44b46ade21759085f713237b436d"}
 	{
 	"ops": [
 	{
@@ -9255,7 +9255,7 @@ V0804 12:34:17.528000 1142858 torch/_inductor/debug.py:700] {"artifact": {"name"
 	"torch.ops._c10d_functional.wait_tensor.default",
 	"torch.ops._c10d_functional.wait_tensor.default"
 	]
-V0804 12:34:17.536000 1142858 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_tlparse_runtime", "encoding": "json"}, "rank": 1, "frame_id": 0, "frame_compile_id": 2, "attempt": 0, "has_payload": "5bdf44b46ade21759085f713237b436d"}
+V0804 12:34:17.536000 1142858 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_runtime_and_tensor_meta", "encoding": "json"}, "rank": 1, "frame_id": 0, "frame_compile_id": 2, "attempt": 0, "has_payload": "5bdf44b46ade21759085f713237b436d"}
 	{
 	"ops": [
 	{
@@ -13078,7 +13078,7 @@ V0804 12:34:17.528000 1142858 torch/_inductor/debug.py:700] {"artifact": {"name"
 	"torch.ops._c10d_functional.wait_tensor.default",
 	"torch.ops._c10d_functional.wait_tensor.default"
 	]
-V0804 12:34:17.536000 1142858 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_tlparse_runtime", "encoding": "json"}, "rank": 1, "frame_id": 0, "frame_compile_id": 3, "attempt": 0, "has_payload": "5bdf44b46ade21759085f713237b436d"}
+V0804 12:34:17.536000 1142858 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_runtime_and_tensor_meta", "encoding": "json"}, "rank": 1, "frame_id": 0, "frame_compile_id": 3, "attempt": 0, "has_payload": "5bdf44b46ade21759085f713237b436d"}
 	{
 	"ops": [
 	{

--- a/tests/inputs/multi_rank_runtime/dedicated_log_torch_trace_rank_2.log
+++ b/tests/inputs/multi_rank_runtime/dedicated_log_torch_trace_rank_2.log
@@ -1683,7 +1683,7 @@ V0804 12:34:15.202000 1142858 torch/_inductor/debug.py:700] {"artifact": {"name"
 	"torch.ops._c10d_functional.all_reduce_.default",
 	"torch.ops._c10d_functional.wait_tensor.default"
 	]
-V0804 12:34:15.305000 1142858 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_tlparse_runtime", "encoding": "json"}, "rank": 2, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "114d64567a1ab3e037f77ad8fb9055c2"}
+V0804 12:34:15.305000 1142858 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_runtime_and_tensor_meta", "encoding": "json"}, "rank": 2, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "114d64567a1ab3e037f77ad8fb9055c2"}
 	{
 	"ops": [
 	{
@@ -5432,7 +5432,7 @@ V0804 12:34:17.528000 1142858 torch/_inductor/debug.py:700] {"artifact": {"name"
 	"torch.ops._c10d_functional.wait_tensor.default",
 	"torch.ops._c10d_functional.wait_tensor.default"
 	]
-V0804 12:34:17.536000 1142858 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_tlparse_runtime", "encoding": "json"}, "rank": 2, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "5bdf44b46ade21759085f713237b436d"}
+V0804 12:34:17.536000 1142858 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_runtime_and_tensor_meta", "encoding": "json"}, "rank": 2, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "5bdf44b46ade21759085f713237b436d"}
 	{
 	"ops": [
 	{
@@ -9255,7 +9255,7 @@ V0804 12:34:17.528000 1142858 torch/_inductor/debug.py:700] {"artifact": {"name"
 	"torch.ops._c10d_functional.wait_tensor.default",
 	"torch.ops._c10d_functional.wait_tensor.default"
 	]
-V0804 12:34:17.536000 1142858 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_tlparse_runtime", "encoding": "json"}, "rank": 2, "frame_id": 0, "frame_compile_id": 2, "attempt": 0, "has_payload": "5bdf44b46ade21759085f713237b436d"}
+V0804 12:34:17.536000 1142858 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_runtime_and_tensor_meta", "encoding": "json"}, "rank": 2, "frame_id": 0, "frame_compile_id": 2, "attempt": 0, "has_payload": "5bdf44b46ade21759085f713237b436d"}
 	{
 	"ops": [
 	{
@@ -13078,7 +13078,7 @@ V0804 12:34:17.528000 1142858 torch/_inductor/debug.py:700] {"artifact": {"name"
 	"torch.ops._c10d_functional.wait_tensor.default",
 	"torch.ops._c10d_functional.wait_tensor.default"
 	]
-V0804 12:34:17.536000 1142858 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_tlparse_runtime", "encoding": "json"}, "rank": 2, "frame_id": 0, "frame_compile_id": 3, "attempt": 0, "has_payload": "5bdf44b46ade21759085f713237b436d"}
+V0804 12:34:17.536000 1142858 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_runtime_and_tensor_meta", "encoding": "json"}, "rank": 2, "frame_id": 0, "frame_compile_id": 3, "attempt": 0, "has_payload": "5bdf44b46ade21759085f713237b436d"}
 	{
 	"ops": [
 	{

--- a/tests/inputs/multi_rank_runtime/dedicated_log_torch_trace_rank_3.log
+++ b/tests/inputs/multi_rank_runtime/dedicated_log_torch_trace_rank_3.log
@@ -1683,7 +1683,7 @@ V0804 12:34:15.202000 1142858 torch/_inductor/debug.py:700] {"artifact": {"name"
 	"torch.ops._c10d_functional.all_reduce_.default",
 	"torch.ops._c10d_functional.wait_tensor.default"
 	]
-V0804 12:34:15.305000 1142858 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_tlparse_runtime", "encoding": "json"}, "rank": 3, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "114d64567a1ab3e037f77ad8fb9055c2"}
+V0804 12:34:15.305000 1142858 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_runtime_and_tensor_meta", "encoding": "json"}, "rank": 3, "frame_id": 0, "frame_compile_id": 0, "attempt": 0, "has_payload": "114d64567a1ab3e037f77ad8fb9055c2"}
 	{
 	"ops": [
 	{
@@ -5432,7 +5432,7 @@ V0804 12:34:17.528000 1142858 torch/_inductor/debug.py:700] {"artifact": {"name"
 	"torch.ops._c10d_functional.wait_tensor.default",
 	"torch.ops._c10d_functional.wait_tensor.default"
 	]
-V0804 12:34:17.536000 1142858 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_tlparse_runtime", "encoding": "json"}, "rank": 3, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "5bdf44b46ade21759085f713237b436d"}
+V0804 12:34:17.536000 1142858 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_runtime_and_tensor_meta", "encoding": "json"}, "rank": 3, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "5bdf44b46ade21759085f713237b436d"}
 	{
 	"ops": [
 	{
@@ -9255,7 +9255,7 @@ V0804 12:34:17.528000 1142858 torch/_inductor/debug.py:700] {"artifact": {"name"
 	"torch.ops._c10d_functional.wait_tensor.default",
 	"torch.ops._c10d_functional.wait_tensor.default"
 	]
-V0804 12:34:17.536000 1142858 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_tlparse_runtime", "encoding": "json"}, "rank": 3, "frame_id": 0, "frame_compile_id": 2, "attempt": 0, "has_payload": "5bdf44b46ade21759085f713237b436d"}
+V0804 12:34:17.536000 1142858 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_runtime_and_tensor_meta", "encoding": "json"}, "rank": 3, "frame_id": 0, "frame_compile_id": 2, "attempt": 0, "has_payload": "5bdf44b46ade21759085f713237b436d"}
 	{
 	"ops": [
 	{
@@ -13078,7 +13078,7 @@ V0804 12:34:17.528000 1142858 torch/_inductor/debug.py:700] {"artifact": {"name"
 	"torch.ops._c10d_functional.wait_tensor.default",
 	"torch.ops._c10d_functional.wait_tensor.default"
 	]
-V0804 12:34:17.536000 1142858 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_tlparse_runtime", "encoding": "json"}, "rank": 3, "frame_id": 0, "frame_compile_id": 3, "attempt": 0, "has_payload": "5bdf44b46ade21759085f713237b436d"}
+V0804 12:34:17.536000 1142858 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_runtime_and_tensor_meta", "encoding": "json"}, "rank": 3, "frame_id": 0, "frame_compile_id": 3, "attempt": 0, "has_payload": "5bdf44b46ade21759085f713237b436d"}
 	{
 	"ops": [
 	{

--- a/tests/inputs/multi_rank_runtime/dedicated_log_torch_trace_rank_4.log
+++ b/tests/inputs/multi_rank_runtime/dedicated_log_torch_trace_rank_4.log
@@ -5397,7 +5397,7 @@ V0804 12:34:17.528000 1142858 torch/_inductor/debug.py:700] {"artifact": {"name"
 	"torch.ops._c10d_functional.wait_tensor.default",
 	"torch.ops._c10d_functional.wait_tensor.default"
 	]
-V0804 12:34:17.536000 1142858 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_tlparse_runtime", "encoding": "json"}, "rank": 4, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "5bdf44b46ade21759085f713237b436d"}
+V0804 12:34:17.536000 1142858 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_runtime_and_tensor_meta", "encoding": "json"}, "rank": 4, "frame_id": 0, "frame_compile_id": 1, "attempt": 0, "has_payload": "5bdf44b46ade21759085f713237b436d"}
 	{
 	"ops": [
 	{
@@ -9220,7 +9220,7 @@ V0804 12:34:17.528000 1142858 torch/_inductor/debug.py:700] {"artifact": {"name"
 	"torch.ops._c10d_functional.wait_tensor.default",
 	"torch.ops._c10d_functional.wait_tensor.default"
 	]
-V0804 12:34:17.536000 1142858 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_tlparse_runtime", "encoding": "json"}, "rank": 4, "frame_id": 0, "frame_compile_id": 2, "attempt": 0, "has_payload": "5bdf44b46ade21759085f713237b436d"}
+V0804 12:34:17.536000 1142858 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_runtime_and_tensor_meta", "encoding": "json"}, "rank": 4, "frame_id": 0, "frame_compile_id": 2, "attempt": 0, "has_payload": "5bdf44b46ade21759085f713237b436d"}
 	{
 	"ops": [
 	{
@@ -13043,7 +13043,7 @@ V0804 12:34:17.528000 1142858 torch/_inductor/debug.py:700] {"artifact": {"name"
 	"torch.ops._c10d_functional.wait_tensor.default",
 	"torch.ops._c10d_functional.wait_tensor.default"
 	]
-V0804 12:34:17.536000 1142858 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_tlparse_runtime", "encoding": "json"}, "rank": 4, "frame_id": 0, "frame_compile_id": 3, "attempt": 0, "has_payload": "5bdf44b46ade21759085f713237b436d"}
+V0804 12:34:17.536000 1142858 torch/_inductor/debug.py:734] {"artifact": {"name": "inductor_runtime_and_tensor_meta", "encoding": "json"}, "rank": 4, "frame_id": 0, "frame_compile_id": 3, "attempt": 0, "has_payload": "5bdf44b46ade21759085f713237b436d"}
 	{
 	"ops": [
 	{


### PR DESCRIPTION
Summary:

- Generate chromium_trace_with_runtime.json from runtime estimations and add metadata so Perfetto shows:
- Processes: one per rank (pid = rank, name “Rank”)
- Threads: one per compiled graph within each rank, named “graph <graph_name>”

Users can pin specific graphs across ranks that they want to compare.

<img width="1266" height="305" alt="image" src="https://github.com/user-attachments/assets/acd9a83e-2799-4c8b-bf68-00c361bba734" />


