### PR TITLE
Add execution order divergence analysis library module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1830,10 +1830,6 @@ pub mod execution_order {
 
     /// Analyze per-rank execution orders, aligning entries by index and flagging issues
     /// using provided per-graph properties.
-    ///
-    /// - `exec_orders`: rank -> ordered list of compile_id directory names
-    /// - `collective_schedule_by_graph`: (rank, compile_id) -> schedule ops sequence
-    /// - `cache_status`: (rank, compile_id) -> cache status marker (e.g., "✅", "❌", "❓")
     pub fn analyze_execution_order(
         exec_orders: &FxHashMap<u32, Vec<String>>,
         collective_schedule_by_graph: &FxHashMap<(u32, String), Vec<String>>,
@@ -1842,7 +1838,6 @@ pub mod execution_order {
         // Determine max length across ranks (N)
         let max_len = exec_orders.values().map(|v| v.len()).max().unwrap_or(0);
 
-        // Fast no-op
         if max_len == 0 || exec_orders.is_empty() {
             return ExecOrderReport::default();
         }
@@ -1911,8 +1906,6 @@ pub mod execution_order {
         ExecOrderReport { by_index: rows }
     }
 
-    /// Parse the JSON payload for `artifact.name = "graph_execution"` and extract
-    /// the `graph_execution_order` sequence.
     pub fn parse_graph_execution_order(payload: &str) -> anyhow::Result<Vec<String>> {
         let value: serde_json::Value = serde_json::from_str(payload)?;
         let arr = value

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2378,7 +2378,6 @@ fn test_execution_order_multi_rank_divergence() -> anyhow::Result<()> {
             1_u32,
             vec!["0/1".to_string(), "0/0".to_string(), "0/2".to_string()],
         ),
-        //           ^^^^^ ^^^^^ Different order at index 0 and 1
     ]
     .into_iter()
     .collect();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2365,3 +2365,75 @@ fn test_tensor_meta_divergence_groups() -> Result<(), Box<dyn std::error::Error>
 
     Ok(())
 }
+
+#[test]
+fn test_execution_order_multi_rank_divergence() -> anyhow::Result<()> {
+    // Test data: Two ranks with different execution orders
+    let exec_orders: fxhash::FxHashMap<u32, Vec<String>> = vec![
+        (
+            0_u32,
+            vec!["0/0".to_string(), "0/1".to_string(), "0/2".to_string()],
+        ),
+        (
+            1_u32,
+            vec!["0/1".to_string(), "0/0".to_string(), "0/2".to_string()],
+        ),
+        //           ^^^^^ ^^^^^ Different order at index 0 and 1
+    ]
+    .into_iter()
+    .collect();
+
+    // Mock collective schedules - different at index 0
+    let collective_schedule_by_graph: fxhash::FxHashMap<(u32, String), Vec<String>> = vec![
+        ((0_u32, "0/0".to_string()), vec!["all_reduce".to_string()]),
+        ((0_u32, "0/1".to_string()), vec!["all_gather".to_string()]),
+        ((1_u32, "0/0".to_string()), vec!["all_reduce".to_string()]),
+        ((1_u32, "0/1".to_string()), vec!["broadcast".to_string()]), // Different!
+    ]
+    .into_iter()
+    .collect();
+
+    // Mock cache status - different at index 1
+    let cache_status: fxhash::FxHashMap<(u32, String), String> = vec![
+        ((0_u32, "0/0".to_string()), "✅".to_string()),
+        ((0_u32, "0/1".to_string()), "❌".to_string()),
+        ((1_u32, "0/0".to_string()), "✅".to_string()),
+        ((1_u32, "0/1".to_string()), "✅".to_string()), // Different!
+    ]
+    .into_iter()
+    .collect();
+
+    let report = tlparse::execution_order::analyze_execution_order(
+        &exec_orders,
+        &collective_schedule_by_graph,
+        &cache_status,
+    );
+
+    assert_eq!(report.by_index.len(), 3);
+
+    // Index 0: Rank 0 has "0/0", Rank 1 has "0/1"
+    // Should detect collective schedule mismatch
+    let row_0 = &report.by_index[0];
+    assert_eq!(row_0.by_rank.get(&0_u32), Some(&"0/0".to_string()));
+    assert_eq!(row_0.by_rank.get(&1_u32), Some(&"0/1".to_string()));
+    assert!(row_0
+        .issues
+        .contains(&tlparse::execution_order::ExecOrderIssue::ScheduleMismatch));
+
+    // Index 1: Rank 0 has "0/1", Rank 1 has "0/0"
+    // Should detect cache mismatch
+    let row_1 = &report.by_index[1];
+    assert_eq!(row_1.by_rank.get(&0_u32), Some(&"0/1".to_string()));
+    assert_eq!(row_1.by_rank.get(&1_u32), Some(&"0/0".to_string()));
+    assert!(row_1
+        .issues
+        .contains(&tlparse::execution_order::ExecOrderIssue::CacheMismatch));
+
+    // Index 2: Both ranks have "0/2" - no issues
+    let row_2 = &report.by_index[2];
+    assert_eq!(row_2.by_rank.get(&0_u32), Some(&"0/2".to_string()));
+    assert_eq!(row_2.by_rank.get(&1_u32), Some(&"0/2".to_string()));
+    assert!(row_2.issues.is_empty());
+
+    Ok(())
+}


### PR DESCRIPTION
What This PR Does
- Adds a new execution_order library module that parses graph execution sequences from PyTorch logs and detects divergences across ranks using existing collective schedule and cache analysis infrastructure.

Key Components
- parse_graph_execution_order(): Extracts compile_id sequences from graph_execution JSON artifacts
- analyze_execution_order(): Aligns ranks by execution index and flags ScheduleMismatch/CacheMismatch issues
- Structured reporting: In-memory ExecOrderReport with per-index divergence details

Integration
- Reuses existing read_collective_schedules() and cache analysis data


Next Steps
- Wire this analysis into --all-ranks-html landing page to display "Execution-Order Diagnostics" section when artifacts are present.